### PR TITLE
Expand the paths checked for ruby-dictionary3

### DIFF
--- a/rplugin/python3/deoplete/sources/totolot.py
+++ b/rplugin/python3/deoplete/sources/totolot.py
@@ -10,20 +10,22 @@ from os.path import expanduser
 
 home = expanduser("~")
 
-d1 = os.path.expanduser("~/.config/nvim/.cache/dein/repos/github.com/takkii/ruby-dictionary3/")
-d2 = os.path.expanduser("~/.config/nvim/repos/github.com/takkii/ruby-dictionary3/")
-d3 = os.path.expanduser("~/.cache/dein/repos/github.com/takkii/ruby-dictionary3/")
+rel_path = "repos/github.com/takkii/ruby-dictionary3/"
+paths = [os.path.expanduser(os.path.join(p, rel_path)) for p in [
+    "~/.cache/dein/",
+    "~/.local/share/dein/",
+    "~/.config/nvim/.cache/dein/",
+    "~/.config/nvim/",
+    "~/.vim/bundles"
+]]
 
-if os.path.exists(d1):
-    ruby_method = open(os.path.expanduser("~/.config/nvim/.cache/dein/repos/github.com/takkii/ruby-dictionary3/autoload/source/ruby_method_deoplete"))
-    rubymotion_method = open(os.path.expanduser("~/.config/nvim/.cache/dein/repos/github.com/takkii/ruby-dictionary3/autoload/source/rubymotion_method"))
-elif os.path.exists(d2):
-    ruby_method = open(os.path.expanduser("~/.config/nvim/repos/github.com/takkii/ruby-dictionary3/autoload/source/ruby_method_deoplete"))
-    rubymotion_method = open(os.path.expanduser("~/.config/nvim/repos/github.com/takkii/ruby-dictionary3/autoload/source/rubymotion_method"))
-elif os.path.exists(d3):
-    ruby_method = open(os.path.expanduser("~/.cache/dein/repos/github.com/takkii/ruby-dictionary3/autoload/source/ruby_method_deoplete"))
-    rubymotion_method = open(os.path.expanduser("~/.cache/dein/repos/github.com/takkii/ruby-dictionary3/autoload/source/rubymotion_method"))
-else:
+try:
+    path = next(p for p in paths if os.path.exists(p))
+
+    ruby_method = open(os.path.join(path, "autoload/source/ruby_method_deoplete"))
+    rubymotion_method = open(os.path.join(path, "autoload/source/rubymotion_method"))
+
+except StopIteration:
     print("Don't forget, Install dein plugin manager github repo takkii/ruby-dictionary3.")
 
 index_ruby = list(ruby_method.readlines()) + list(rubymotion_method.readlines())


### PR DESCRIPTION
Adding paths to ruby-dictionary3 from the recommended Dein installation paths here:
➡️ https://github.com/Shougo/dein.vim

Also refactored the code to make it more DRY, using list comprehensions
to build paths and check them.

To fix issue: #3 

（これは自動翻訳です。申し訳ありませんが、私の日本語はとても悪いです！）

ここで推奨されるDeinインストールパスからruby-dictionary3へのパスを追加します。
➡️ https://github.com/Shougo/dein.vim

また、コードをリファクタリングして、よりD.R.Yにしました。 Pythonリスト内包表記を使用してパスを作成し、チェックします。

問題を修正するには：＃3